### PR TITLE
Fix relative paths for scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ A simple web scraper that allows you to download images from specified URLs via 
 2. **Install Dependencies**.<br>
    Install the required packages listed in `requirements.txt`:
    ```
-   pip install -r requirements.txt
+   pip install -r src/requirements.txt
    ```
 
 3. **Run the Auto Update Script**.<br>
    Ensure all dependencies are up to date:
    ```
-   python auto_update.py
+   python src/auto_update.py
    ```
 
 4. **Start the Local Server**.<br>
    Run the local server to access the web interface:
    ```
-   python local_server.py
+   python src/local_server.py
    ```
 
 5. **Access the Web Interface**.<br>
@@ -47,7 +47,7 @@ A simple web scraper that allows you to download images from specified URLs via 
 
 6. **Alternatively, run the GUI version:**.<br>
    ```
-   py .\scraper_gui.py
+   python src/scraper_gui.py
    ```
 
 ## Usage

--- a/src/auto_update.py
+++ b/src/auto_update.py
@@ -2,17 +2,19 @@ import subprocess
 import sys
 from datetime import datetime
 import os
+from pathlib import Path
 
 def update_packages():
-    log_dir = "Update Logs"
-    if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
-    log_file = os.path.join(log_dir, datetime.now().strftime("update_log_%Y-%m-%d_%H-%M-%S.txt"))
+    base_dir = Path(__file__).resolve().parent
+    log_dir = base_dir / "Update Logs"
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / datetime.now().strftime("update_log_%Y-%m-%d_%H-%M-%S.txt")
     
     with open(log_file, "a") as log:
         log.write(f"Update started at {datetime.now()}\n\n")
                 
-        with open("requirements.txt", "r") as file:
+        requirements_path = base_dir / "requirements.txt"
+        with open(requirements_path, "r") as file:
             packages = file.readlines()
 
         for package in packages:

--- a/src/local_server.py
+++ b/src/local_server.py
@@ -2,9 +2,12 @@ import http.server
 import socketserver
 import urllib.parse
 import webbrowser
+from pathlib import Path
 from io import StringIO
 from scraper import scrape_images
-from auto_update import update_packages  
+from auto_update import update_packages
+
+BASE_DIR = Path(__file__).resolve().parent
 
 class MyHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
@@ -12,7 +15,8 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
-            with open('scraper_interface.html', 'rb') as file:
+            interface_path = BASE_DIR / 'scraper_interface.html'
+            with open(interface_path, 'rb') as file:
                 self.wfile.write(file.read())
         elif self.path == '/update':
             self.send_response(200)
@@ -42,7 +46,8 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
 
             # Read the HTML file
-            with open('scraper_interface.html', 'r') as file:
+            interface_path = BASE_DIR / 'scraper_interface.html'
+            with open(interface_path, 'r') as file:
                 html_content = file.read()
 
             # Insert the result into the HTML

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -23,12 +23,10 @@ def scrape_images(url):
     # Extract the image name from the URL
     image_name = url.split("/artwork/")[1]
     safe_image_name = sanitize_path_component(image_name)
+    base_dir = Path(__file__).resolve().parent
     # Directory name to save the images
-    directory_name = "Scraped"
-    base_path = Path(directory_name).resolve()
-    # Create a directory if it doesn't exist
-    if not os.path.exists(directory_name):
-        os.makedirs(directory_name)
+    base_path = (base_dir / "Scraped").resolve()
+    base_path.mkdir(exist_ok=True)
     # Selenium setup with webdriver_manager to automatically manage the ChromeDriver
     options = Options()
     options.add_argument('--ignore-certificate-errors')
@@ -60,9 +58,9 @@ def scrape_images(url):
                 unique_urls.add(modified_url)
     # Download the unique images
     num_images_downloaded = 0
-    for url in unique_urls:
+    for img_url in unique_urls:
         try:
-            file_extension = os.path.splitext(urlparse(url).path)[1]
+            file_extension = os.path.splitext(urlparse(img_url).path)[1]
             safe_extension = sanitize_path_component(file_extension)
             
             filename = f"{safe_image_name}_{num_images_downloaded}.{safe_extension.lstrip('.')}"
@@ -72,13 +70,13 @@ def scrape_images(url):
                 print(f"Skipping suspicious path: {filename}")
                 continue
             
-            response = requests.get(url)
+            response = requests.get(img_url)
             response.raise_for_status()
             with open(image_path, "wb") as file:
                 file.write(response.content)
             num_images_downloaded += 1
         except requests.exceptions.RequestException as e:
-            print(f"Error downloading image: {url}")
+            print(f"Error downloading image: {img_url}")
             print(f"Error details: {str(e)}")
     # Close the webdriver
     driver.quit()


### PR DESCRIPTION
## Summary
- make auto_update use paths relative to its own file
- make local_server read the HTML from its directory
- create images in a consistent location
- update README usage examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e96a0598832a8bd89ef3494af105